### PR TITLE
Adding the ability to configure via environment variables during runtime

### DIFF
--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,0 +1,38 @@
+require IEx
+
+defmodule Aggie.Config do
+
+  @moduledoc """
+  Aggie.Config pulls env variables for app configuration during runtime.
+  """
+
+  @doc """
+  Goes through aggie environment variables and populates the application config
+  """
+  def populate_app_config() do
+
+    # Get env variables on runtime and activate
+    source_ip = System.get_env("AGGIE_SOURCE_IP")
+    Application.put_env(:aggie, :source_ip, source_ip)
+
+    source_port = System.get_env("AGGIE_SOURCE_PORT")
+    Application.put_env(:aggie, :source_port, source_port)
+
+    source_timeout = System.get_env("AGGIE_SOURCE_TIMEOUT")
+    Application.put_env(:aggie, :source_timeout, source_timeout)
+
+    source_range = System.get_env("AGGIE_SOURCE_RANGE")
+    Application.put_env(:aggie, :source_range, source_range)
+
+    source_chunks = System.get_env("AGGIE_SOURCE_CHUNKS")
+    Application.put_env(:aggie, :source_chunks, source_chunks)
+
+    destination_ip = System.get_env("AGGIE_DESTINATION_IP")
+    Application.put_env(:aggie, :destination_ip, destination_ip)
+
+    destination_port = System.get_env("AGGIE_DESTINATION_PORT")
+    Application.put_env(:aggie, :destination_port, destination_port)
+
+  end
+
+end

--- a/lib/shipper.ex
+++ b/lib/shipper.ex
@@ -2,8 +2,6 @@ require IEx
 
 defmodule Aggie.Shipper do
 
-  @central_elk "10.208.200.40:9200"
-
   @doc """
   Forwards the latest valuable logs from local ELK to Central ELK
   """
@@ -48,7 +46,11 @@ defmodule Aggie.Shipper do
   end
 
   defp post!(log) do
-    url         = "#{@central_elk}/#{index()}/log"
+
+    destination_ip = Application.get_env(:aggie, :destination_ip)
+    destination_port = Application.get_env(:aggie, :destination_port)
+
+    url         = "#{destination_ip}:#{destination_port}/#{index()}/log"
     headers     = [{"Content-Type", "application/json"}]
     {:ok, json} = Poison.encode(log)
 


### PR DESCRIPTION
Author: Shannon Mitchell
Date: Fri Apr  7 19:35:17 UTC 2017

  Adding the ability to configure via environment variables during runtime.
  It looks like an elixir release package only reads in the config.exe
  during compile time. There are a few methods to change the config during
  runtime and this one seems the easiest(and works).  You can place the vars
  in your environment and source them before running the prog.

  cat /etc/aggie/config

  export AGGIE_SOURCE_IP="1.2.3.4"
  export AGGIE_SOURCE_PORT="9200"
  export AGGIE_SOURCE_TIMEOUT="1m"
  export AGGIE_SOURCE_CHUNKS="1000"
  export AGGIE_SOURCE_RANGE="now-10m"
  export AGGIE_DESTINATION_IP="4.3.2.1"
  export AGGIE_DESTINATION_PORT="9200"