### PR TITLE
Fix compile time config issue and post script hang

### DIFF
--- a/lib/aggie.ex
+++ b/lib/aggie.ex
@@ -16,6 +16,7 @@ defmodule Aggie do
     HTTPoison.start()
     Config.populate_app_config()
     Shipper.ship!(latest_logs())
+    System.halt(0)
   end
 
   @doc """

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -20,7 +20,7 @@ defmodule Aggie.Config do
   @doc """
   Goes through aggie environment variables and populates the application config
   """
-  defmacro populate_app_config do
+  def populate_app_config do
     Enum.each @required, fn(tuple) ->
       var     = elem(tuple, 0)
       env_var = elem(tuple, 1)


### PR DESCRIPTION
Author: Shannon Mitchell <shannon.mitchell@rackspace.com>
Date: Tue Apr 11 20:51:37 UTC 2017

  - Looks like the macro was evaluating the config entries at compile time
    causing issues during runtime.  Changing the macro to a normal function
    def fixed the issue.

  - The script was hanging after the initial run.  It looks like you can do
    a System.halt(0) to cause the runtime environment to shut down properly
    after the task is complete.